### PR TITLE
Use ctru-sys from rust3ds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ license = "MIT/Apache 2.0"
 edition = "2018"
 
 [dependencies]
-ctru-sys = { git = "https://github.com/Meziu/ctru-rs.git" }
+ctru-sys = { git = "https://github.com/rust3ds/ctru-rs.git" }
 libc = "0.2.126"


### PR DESCRIPTION
This ensures that both `ctru-rs` and this library are depending on the same instance of `ctru-sys`. Otherwise the compiler complains about trying to link in multiple copies of libctru in the same build.